### PR TITLE
Fix seg-fault error in shark_runner, added hugging-face models.

### DIFF
--- a/examples/hugging_face_models.py
+++ b/examples/hugging_face_models.py
@@ -1,0 +1,39 @@
+import torch
+from torchvision import transforms
+from transformers import AutoTokenizer, AutoModelForSequenceClassification
+from shark_runner import shark_inference
+
+torch.manual_seed(0)
+
+models = ["albert-base-v2", "distilbert-base-uncased", "bert-base-uncased"]
+
+
+def prepare_sentence_tokens(tokenizer, sentence):
+    return torch.tensor([tokenizer.encode(sentence)])
+
+
+class HuggingFaceLanguage(torch.nn.Module):
+    def __init__(self, hf_model_name):
+        super().__init__()
+        self.model = AutoModelForSequenceClassification.from_pretrained(
+            hf_model_name,  # The pretrained model.
+            num_labels=2,  # The number of output labels--2 for binary classification.
+            output_attentions=False,  # Whether the model returns attentions weights.
+            output_hidden_states=False,  # Whether the model returns all hidden-states.
+            torchscript=True,
+        )
+
+    def forward(self, tokens):
+        return self.model.forward(tokens)[0]
+
+
+for hf_model in models:
+    tokenizer = AutoTokenizer.from_pretrained(hf_model)
+    test_input = prepare_sentence_tokens(tokenizer, "this project is very interesting")
+    results = shark_inference(
+        HuggingFaceLanguage(hf_model),
+        test_input,
+        device="cpu",
+        dynamic=False,
+        jit_trace=True,
+    )

--- a/examples/shark_runner.py
+++ b/examples/shark_runner.py
@@ -103,4 +103,6 @@ def shark_inference(module, input, device="cpu", dynamic=False, jit_trace=False)
     ctx.add_vm_module(vm_module)
     ModuleCompiled = ctx.modules.module["forward"]
     result = ModuleCompiled(input.numpy())
-    return np.asarray(result, dtype=np.float32)
+    result_numpy = np.asarray(result, dtype=np.float32)
+    result_copy = np.copy(result_numpy)
+    return result_copy


### PR DESCRIPTION
Returning the copy of numpy array solves the seg-fault issue while
running shark_inference. Added common template to run hugging-face
models.